### PR TITLE
Inherit touchable opacity props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleProp, ViewStyle } from 'react-native';
+import { StyleProp, ViewStyle, TouchableOpacityProps } from 'react-native';
 
 type Props = {
   popover?: React.ReactElement<{}>;
@@ -15,7 +15,7 @@ type Props = {
   overlayColor?: string,
   backgroundColor?: string,
   highlightColor?: string,
-};
+} & TouchableOpacityProps;
 
 export default class Tooltip extends React.Component<Props, any> {
   toggleTooltip: () => void;

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -6,6 +6,7 @@ import {
   Modal,
   View,
   ViewPropTypes as RNViewPropTypes,
+  TouchableOpacityProps as RNTouchableOpacityProps,
 } from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -14,6 +15,7 @@ import { ScreenWidth, ScreenHeight, isIOS } from './helpers';
 import getTooltipCoordinate from './getTooltipCoordinate';
 
 const ViewPropTypes = RNViewPropTypes || View.propTypes;
+const TouchableOpacityProps = RNTouchableOpacityProps || TouchableOpacity.propTypes;
 
 type State = {
   isVisible: boolean,
@@ -37,7 +39,7 @@ type Props = {
   overlayColor: string,
   backgroundColor: string,
   highlightColor: string,
-};
+} & TouchableOpacityProps;
 
 class Tooltip extends React.Component<Props, State> {
   state = {
@@ -65,7 +67,7 @@ class Tooltip extends React.Component<Props, State> {
   wrapWithPress = (toggleOnPress, children) => {
     if (toggleOnPress) {
       return (
-        <TouchableOpacity onPress={this.toggleTooltip} activeOpacity={1}>
+        <TouchableOpacity onPress={this.toggleTooltip} activeOpacity={1} {...this.props}>
           {children}
         </TouchableOpacity>
       );


### PR DESCRIPTION
I wanted to adjust the `activeOpacity` and add some `hitSlop` to the toggle component, and have found the best (and non-breaking) way is to pass `...this.props` to the `TouchableOpacity` wrapping `children`.

This then allows for something like-

```
<Tooltip
  ref={this.tooltipRef}
  height={options.length * (24 + size(2)) + size(2)}
  width={250}
  withPointer
  popover={
    <PopoverOptions
      options={options}
    />
  }
  // Other TouchableOpacity props below :)
  activeOpacity={0.2}
  hitSlop={hitSlop(20)}
>
  <ThreeDotsSvg />
</Tooltip>
```

