### PR TITLE
Expand touchable props

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ import Tooltip from 'rn-tooltip';
 * [`withOverlay`](#withOverlay)
 * [`overlayColor`](#withOverlay)
 * [`withPointer`](#withPointer)
+* [`toggleWrapperProps`](#toggleWrapperProps)
 
 ---
 
@@ -182,5 +183,14 @@ Flag to determine whether or not dislay pointer.
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  true   |
+
+### `toggleWrapperProps`
+
+Drills TouchableOpacity Props down to the TouchableOpacity wrapper that toggles the Tooltip.
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| TouchableOpacityProps | {} |
+
 
 **MIT Licensed**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleProp, ViewStyle } from 'react-native';
+import { StyleProp, ViewStyle, TouchableOpacityProps } from 'react-native';
 
 type Props = {
   popover?: React.ReactElement<{}>;
@@ -15,6 +15,7 @@ type Props = {
   overlayColor?: string,
   backgroundColor?: string,
   highlightColor?: string,
+  toggleWrapperProps?: TouchableOpacityProps,
 };
 
 export default class Tooltip extends React.Component<Props, any> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-tooltip",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "main": "src/Tooltip.js",
   "homepage": "https://github.com/AndreiCalazans/rn-tooltip#readme",
   "repository": {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -37,6 +37,7 @@ type Props = {
   overlayColor: string,
   backgroundColor: string,
   highlightColor: string,
+  toggleWrapperProps: {},
 };
 
 class Tooltip extends React.Component<Props, State> {
@@ -65,7 +66,11 @@ class Tooltip extends React.Component<Props, State> {
   wrapWithPress = (toggleOnPress, children) => {
     if (toggleOnPress) {
       return (
-        <TouchableOpacity onPress={this.toggleTooltip} activeOpacity={1}>
+        <TouchableOpacity
+          onPress={this.toggleTooltip}
+          activeOpacity={1}
+          {...this.props.toggleWrapperProps}
+        >
           {children}
         </TouchableOpacity>
       );
@@ -222,12 +227,14 @@ Tooltip.propTypes = {
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
   withOverlay: PropTypes.bool,
+  toggleWrapperProps: PropTypes.object,
   overlayColor: PropTypes.string,
   backgroundColor: PropTypes.string,
   highlightColor: PropTypes.string,
 };
 
 Tooltip.defaultProps = {
+  toggleWrapperProps: {},
   withOverlay: true,
   highlightColor: 'transparent',
   withPointer: true,


### PR DESCRIPTION
Improve Tooltip by allowing props injection to the TouchableOpacity wrapper.
