### PR TITLE
fix(back): onRequestClose prop, toggle is default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ import Tooltip from 'rn-tooltip';
 * [`overlayColor`](#withOverlay)
 * [`withPointer`](#withPointer)
 * [`toggleWrapperProps`](#toggleWrapperProps)
+* [`onRequestClose`](#onRequestClose)
 
 ---
 
@@ -200,6 +201,14 @@ Drills TouchableOpacity Props down to the TouchableOpacity wrapper that toggles 
 |      Type      |      Default      |
 | :------------: | :---------------: |
 | TouchableOpacityProps | {} |
+
+### `onRequestClose`
+
+Used on Android, this is called when back button is pressed on android.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| function |  undefined  |
 
 
 **MIT Licensed**

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -33,6 +33,7 @@ type Props = {
   pointerStyle: {},
   onClose: () => void,
   onOpen: () => void,
+  onRequestClose: () => void,
   withOverlay: boolean,
   overlayColor: string,
   backgroundColor: string,
@@ -202,6 +203,15 @@ class Tooltip extends React.Component<Props, State> {
       );
   };
 
+  onRequestClose = () => {
+    const { onRequestClose } = this.props;
+    if (onRequestClose) {
+      onRequestClose();
+    } else {
+      this.toggleTooltip();
+    }
+  };
+
   render() {
     const { isVisible } = this.state;
     const { onClose, withOverlay, onOpen, overlayColor } = this.props;
@@ -215,7 +225,7 @@ class Tooltip extends React.Component<Props, State> {
           transparent
           onDismiss={onClose}
           onShow={onOpen}
-          onRequestClose={onClose}
+          onRequestClose={this.onRequestClose}
         >
           <TouchableOpacity
             style={styles.container(withOverlay, overlayColor)}


### PR DESCRIPTION
Fixes: https://github.com/AndreiCalazans/rn-tooltip/issues/49
Added onRequestClose prop, and toggle tooltip is the default behavior if the prop is null