### PR TITLE
Support string proptype on height param

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -243,7 +243,7 @@ Tooltip.propTypes = {
   children: PropTypes.element,
   withPointer: PropTypes.bool,
   popover: PropTypes.element,
-  height: PropTypes.number,
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   containerStyle: ViewPropTypes.style,
   pointerColor: PropTypes.string,


### PR DESCRIPTION
According to the documentation the `height` property can be set to `"auto"` to make sure the tooltip size adapts to dynamic content. When doing so the proptype check complains that height should be a number. This change allows the use of strings (such as `"auto"` or `"100%"`).