### PR TITLE
Fix auto height tooltip coordinate calculation when past middle line

### DIFF
--- a/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -53,89 +53,87 @@ exports[`Tooltip component should display tooltip on longPress 1`] = `
         }
       }
     >
-      <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "transparent",
+            "height": 0,
+            "left": 0,
+            "overflow": "visible",
+            "position": "absolute",
+            "right": null,
+            "top": 0,
+            "width": 0,
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          Press me
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "left": -7.5,
+            "position": "absolute",
+            "right": null,
+            "top": -2,
+          }
+        }
+      >
         <View
           style={
-            Object {
-              "backgroundColor": "transparent",
-              "height": 0,
-              "left": 0,
-              "overflow": "visible",
-              "position": "absolute",
-              "right": null,
-              "top": 0,
-              "width": 0,
-            }
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "borderBottomColor": "white",
+                "borderBottomWidth": 15,
+                "borderLeftColor": "transparent",
+                "borderLeftWidth": 8,
+                "borderRightColor": "transparent",
+                "borderRightWidth": 8,
+                "borderStyle": "solid",
+                "height": 0,
+                "width": 0,
+              },
+              Object {
+                "borderBottomColor": "#617080",
+              },
+              Object {},
+            ]
           }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-          >
-            Press me
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "left": -7.5,
-              "position": "absolute",
-              "right": null,
-              "top": -2,
-            }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#617080",
+            "borderRadius": 10,
+            "display": "flex",
+            "flex": 1,
+            "height": 100,
+            "justifyContent": "center",
+            "left": -17.999,
+            "padding": 10,
+            "position": "absolute",
+            "right": null,
+            "top": 10,
+            "width": 200,
           }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderBottomColor": "white",
-                  "borderBottomWidth": 15,
-                  "borderLeftColor": "transparent",
-                  "borderLeftWidth": 8,
-                  "borderRightColor": "transparent",
-                  "borderRightWidth": 8,
-                  "borderStyle": "solid",
-                  "height": 0,
-                  "width": 0,
-                },
-                Object {
-                  "borderBottomColor": "#617080",
-                },
-                Object {},
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#617080",
-              "borderRadius": 10,
-              "display": "flex",
-              "flex": 1,
-              "height": 100,
-              "justifyContent": "center",
-              "left": -17.999,
-              "padding": 10,
-              "position": "absolute",
-              "right": null,
-              "top": 10,
-              "width": 200,
-            }
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-          >
-            Info here
-          </Text>
-        </View>
+          Info here
+        </Text>
       </View>
     </View>
   </Modal>
@@ -195,89 +193,87 @@ exports[`Tooltip component should display tooltip when no actionType is provided
         }
       }
     >
-      <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "transparent",
+            "height": 0,
+            "left": 0,
+            "overflow": "visible",
+            "position": "absolute",
+            "right": null,
+            "top": 0,
+            "width": 0,
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          Press me
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "left": -7.5,
+            "position": "absolute",
+            "right": null,
+            "top": -2,
+          }
+        }
+      >
         <View
           style={
-            Object {
-              "backgroundColor": "transparent",
-              "height": 0,
-              "left": 0,
-              "overflow": "visible",
-              "position": "absolute",
-              "right": null,
-              "top": 0,
-              "width": 0,
-            }
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "borderBottomColor": "white",
+                "borderBottomWidth": 15,
+                "borderLeftColor": "transparent",
+                "borderLeftWidth": 8,
+                "borderRightColor": "transparent",
+                "borderRightWidth": 8,
+                "borderStyle": "solid",
+                "height": 0,
+                "width": 0,
+              },
+              Object {
+                "borderBottomColor": "#617080",
+              },
+              Object {},
+            ]
           }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-          >
-            Press me
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "left": -7.5,
-              "position": "absolute",
-              "right": null,
-              "top": -2,
-            }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#617080",
+            "borderRadius": 10,
+            "display": "flex",
+            "flex": 1,
+            "height": 100,
+            "justifyContent": "center",
+            "left": -17.999,
+            "padding": 10,
+            "position": "absolute",
+            "right": null,
+            "top": 10,
+            "width": 200,
           }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderBottomColor": "white",
-                  "borderBottomWidth": 15,
-                  "borderLeftColor": "transparent",
-                  "borderLeftWidth": 8,
-                  "borderRightColor": "transparent",
-                  "borderRightWidth": 8,
-                  "borderStyle": "solid",
-                  "height": 0,
-                  "width": 0,
-                },
-                Object {
-                  "borderBottomColor": "#617080",
-                },
-                Object {},
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#617080",
-              "borderRadius": 10,
-              "display": "flex",
-              "flex": 1,
-              "height": 100,
-              "justifyContent": "center",
-              "left": -17.999,
-              "padding": 10,
-              "position": "absolute",
-              "right": null,
-              "top": 10,
-              "width": 200,
-            }
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-          >
-            Info here
-          </Text>
-        </View>
+          Info here
+        </Text>
       </View>
     </View>
   </Modal>
@@ -337,89 +333,87 @@ exports[`Tooltip component should render without issues 1`] = `
         }
       }
     >
-      <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "transparent",
+            "height": 0,
+            "left": 0,
+            "overflow": "visible",
+            "position": "absolute",
+            "right": null,
+            "top": 0,
+            "width": 0,
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          Press me
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "left": -7.5,
+            "position": "absolute",
+            "right": null,
+            "top": -2,
+          }
+        }
+      >
         <View
           style={
-            Object {
-              "backgroundColor": "transparent",
-              "height": 0,
-              "left": 0,
-              "overflow": "visible",
-              "position": "absolute",
-              "right": null,
-              "top": 0,
-              "width": 0,
-            }
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "borderBottomColor": "white",
+                "borderBottomWidth": 15,
+                "borderLeftColor": "transparent",
+                "borderLeftWidth": 8,
+                "borderRightColor": "transparent",
+                "borderRightWidth": 8,
+                "borderStyle": "solid",
+                "height": 0,
+                "width": 0,
+              },
+              Object {
+                "borderBottomColor": "#617080",
+              },
+              Object {},
+            ]
           }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-          >
-            Press me
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "left": -7.5,
-              "position": "absolute",
-              "right": null,
-              "top": -2,
-            }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#617080",
+            "borderRadius": 10,
+            "display": "flex",
+            "flex": 1,
+            "height": 40,
+            "justifyContent": "center",
+            "left": -17.999,
+            "padding": 10,
+            "position": "absolute",
+            "right": null,
+            "top": 10,
+            "width": 150,
           }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderBottomColor": "white",
-                  "borderBottomWidth": 15,
-                  "borderLeftColor": "transparent",
-                  "borderLeftWidth": 8,
-                  "borderRightColor": "transparent",
-                  "borderRightWidth": 8,
-                  "borderStyle": "solid",
-                  "height": 0,
-                  "width": 0,
-                },
-                Object {
-                  "borderBottomColor": "#617080",
-                },
-                Object {},
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#617080",
-              "borderRadius": 10,
-              "display": "flex",
-              "flex": 1,
-              "height": 40,
-              "justifyContent": "center",
-              "left": -17.999,
-              "padding": 10,
-              "position": "absolute",
-              "right": null,
-              "top": 10,
-              "width": 150,
-            }
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-          >
-            Info here
-          </Text>
-        </View>
+          Info here
+        </Text>
       </View>
     </View>
   </Modal>

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -111,7 +111,6 @@ class Tooltip extends React.Component<Props, State> {
       ScreenWidth,
       ScreenHeight,
       width,
-      height,
       withPointer,
     );
 

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -115,11 +115,10 @@ class Tooltip extends React.Component<Props, State> {
       withPointer,
     );
 
-    return {
+    const tooltipStyle = {
       position: 'absolute',
       left: I18nManager.isRTL ? null : x,
       right: I18nManager.isRTL ? x : null,
-      top: y,
       width,
       height,
       backgroundColor,
@@ -132,12 +131,20 @@ class Tooltip extends React.Component<Props, State> {
       padding: 10,
       ...containerStyle,
     };
+
+    const pastMiddleLine = yOffset > y;
+    if (pastMiddleLine) {
+      tooltipStyle.bottom = ScreenHeight - y;
+    } else {
+      tooltipStyle.top = y;
+    }
+
+    return tooltipStyle;
   };
 
-  renderPointer = tooltipY => {
+  renderPointer = pastMiddleLine => {
     const { yOffset, xOffset, elementHeight, elementWidth } = this.state;
     const { backgroundColor, pointerColor, pointerStyle } = this.props;
-    const pastMiddleLine = yOffset > tooltipY;
 
     return (
       <View
@@ -167,7 +174,7 @@ class Tooltip extends React.Component<Props, State> {
     const { yOffset, xOffset, elementWidth, elementHeight } = this.state;
     const tooltipStyle = this.getTooltipStyle();
     return (
-      <View>
+      <React.Fragment>
         <View
           style={{
             position: 'absolute',
@@ -182,9 +189,9 @@ class Tooltip extends React.Component<Props, State> {
         >
           {this.props.children}
         </View>
-        {withPointer && this.renderPointer(tooltipStyle.top)}
+        {withPointer && this.renderPointer(!tooltipStyle.top)}
         <View style={tooltipStyle}>{popover}</View>
-      </View>
+      </React.Fragment>
     );
   };
 

--- a/src/getTooltipCoordinate.js
+++ b/src/getTooltipCoordinate.js
@@ -2,8 +2,6 @@
 import { Dimensions } from 'react-native';
 
 function convertDimensionToNumber(dimension, screenDimension) {
-  if (dimension === 'auto') return 0;
-
   if (typeof dimension === 'string' && dimension.includes('%')) {
     const decimal = Number(dimension.replace(/%/, '')) / 100;
     return decimal * screenDimension;
@@ -30,7 +28,7 @@ type Coord = {
   The tooltip coordinates are based on the element which it is wrapping.
   We take the x and y coordinates of the element and find the best position
   to place the tooltip. To find the best position we look for the side with the
-  most space. In order to find the side with the most space we divide the the 
+  most space. In order to find the side with the most space we divide the the
   surroundings in four quadrants and check for the one with biggest area.
   Once we know the quandrant with the biggest area it place the tooltip in that
   direction.
@@ -50,7 +48,6 @@ const getTooltipCoordinate = (
   ScreenWidth: number,
   ScreenHeight: number,
   receivedTooltipWidth: number | string,
-  receivedTooltipHeight: number | string,
   withPointer: boolean,
 ): Coord => {
   const screenDims = Dimensions.get('screen');
@@ -58,10 +55,6 @@ const getTooltipCoordinate = (
   const tooltipWidth = convertDimensionToNumber(
     receivedTooltipWidth,
     screenDims.width,
-  );
-  const tooltipHeight = convertDimensionToNumber(
-    receivedTooltipHeight,
-    screenDims.height,
   );
   // The following are point coordinates: [x, y]
   const center = [x + width / 2, y + height / 2];
@@ -98,8 +91,8 @@ const getTooltipCoordinate = (
   // Deslocate the coordinates in the direction of the quadrant.
   const directionCorrection = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
   const deslocateReferencePoint = [
-    [-tooltipWidth, -tooltipHeight],
-    [0, -tooltipHeight],
+    [-tooltipWidth, 0],
+    [0, 0],
     [0, 0],
     [-tooltipWidth, 0],
   ];

--- a/src/getTooltipCoordinate.js
+++ b/src/getTooltipCoordinate.js
@@ -2,6 +2,8 @@
 import { Dimensions } from 'react-native';
 
 function convertDimensionToNumber(dimension, screenDimension) {
+  if (dimension === 'auto') return 0;
+
   if (typeof dimension === 'string' && dimension.includes('%')) {
     const decimal = Number(dimension.replace(/%/, '')) / 100;
     return decimal * screenDimension;


### PR DESCRIPTION
First, thanks for providing this library! It's helped us implement nice tooltips fast and easily. 

## Context

As for this PR: We are using the suggested `height="auto"` setting to deal with unknown content for the tooltips. This works excellent when the triggering component is in the top region of the screen, but we started running into issues when the triggering component is located in the bottom of the screen.

## The issue

The crash we were seeing was caused by a `NaN` error in the height calculation because `convertDimensionToNumber` was only expecting the value of `dimension` to be a number or percentage based string. Returning `Number("auto")` resulted in an exception.

## The fix

This turned out to be a complex problem. Ideally we would just return the current component height in `convertDimensionToNumber`, but since that is calculated after a timeout this number is not known in that method. When the tooltip is shown below the triggering component this does not matter since we only need to calculate the Y-offset from that element (regardless of the size of the tooltip). When it is shown above the component however, we need to calculate `Y - height` to display it correctly.

The solution direction I chose is to instead calculate the tooltip position from the **bottom** when it is displayed above the triggering component. This gives us a mirrored situation from the other case, which means we no longer need to care about the tooltip's actual height.

I approached this by making the following changes:

1. When the tooltip is rendered past the middle line, the absolute position is set from the bottom instead of the top.
1. The `renderPointer` method was relying on `tooltipStyle.top` to decide how to render. It now takes a boolean to indicate that and the caller is responsible for deducing which situation we are in (I choose to base it on the presence of `tooltipStyle.top` since we now only set that when rendering above the middle line).
1. The `renderContent` wrapper was changed from a `View` to a `React.Fragment`. The default properties of a View meant that bottom positioning was not possible. The Fragment does not impact styling.
1. The height of the tooltip can now be removed from the area calculation as it no longer plays a role in positioning the tooltip. This means the `convertDimensionToNumber` will no longer be called for the height which fixes the issue :-)

## Testing

Snapshots are updated. Sorry for the amount of changes, this is caused by swapping the wrapper View for a React.Fragment. 

I tried to test many permutations, but I'm not familiar enough with the library to know for sure if I handled possible edge cases. It might be a good idea to do some manual testing before merging this.