### PR TITLE
74: fixes Android container's bottom position

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -11,7 +11,12 @@ import {
 import PropTypes from 'prop-types';
 
 import Triangle from './Triangle';
-import { ScreenWidth, ScreenHeight, isIOS } from './helpers';
+import {
+  ScreenWidth,
+  ScreenHeight,
+  ActualScreenHeight,
+  isIOS,
+} from './helpers';
 import getTooltipCoordinate from './getTooltipCoordinate';
 
 const ViewPropTypes = RNViewPropTypes || View.propTypes;
@@ -133,7 +138,7 @@ class Tooltip extends React.Component<Props, State> {
 
     const pastMiddleLine = yOffset > y;
     if (pastMiddleLine) {
-      tooltipStyle.bottom = ScreenHeight - y;
+      tooltipStyle.bottom = ActualScreenHeight - y;
     } else {
       tooltipStyle.top = y;
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,10 +1,19 @@
 //  @flow
 
-import { Platform, Dimensions } from 'react-native';
+import { Platform, Dimensions, StatusBar } from 'react-native';
 
 const Screen = Dimensions.get('window');
 export const ScreenWidth: number = Screen.width;
 export const ScreenHeight: number = Screen.height;
+
+export const ActualScreenHeight = Platform.select({
+  ios: ScreenHeight,
+  android:
+    StatusBar.currentHeight > 24
+      ? ScreenHeight
+      : ScreenHeight - StatusBar.currentHeight,
+});
+
 export const isIOS = Platform.OS === 'ios';
 
 export const Colors = {


### PR DESCRIPTION
### Reference Issues
Android issue padding between pointer and container 74.
[Link](https://github.com/AndreiCalazans/rn-tooltip/issues/74)

### Fix explanation
Dimensions.get('window').height returns wrong height on Android. Here is an open react native [issue](https://github.com/facebook/react-native/issues/23693).

I've modified screenHeight calculations depending on the system, and the status bar height.
