### PR TITLE
Update types to support React 18

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,8 @@ type Props = {
   backgroundColor?: string,
   highlightColor?: string,
   toggleWrapperProps?: TouchableOpacityProps,
-  actionType: 'press' | 'longPress' | 'none'
+  actionType: 'press' | 'longPress' | 'none',
+  children: React.ReactNode
 };
 
 export default class Tooltip extends React.Component<Props, any> {


### PR DESCRIPTION
As `children` has been removed from React 18 so we need to merge this change asap.