### PR TITLE
exposing type Props

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -19,7 +19,7 @@ type State = {
   elementHeight: number,
 };
 
-type Props = {
+export type Props = {
   withPointer: boolean,
   popover: React.Element,
   height: number | string,


### PR DESCRIPTION
exposing the type Props, will allow an easy way to extend the Tooltip component. Ex

```typescript
import React from "react";
import RNTooltip, { TooltipProps as RNTooltipProps } from "rn-tooltip";

interface TooltipProps extends Partial<RNTooltipProps> {
  aNewProp: string;
}

const Tooltip: React.FC<TooltipProps> = (props) => {
  return (
    <RNTooltip {...props} actionType="press" withOverlay={false}>
      {props.children}
    </RNTooltip>
  );
};

```